### PR TITLE
Use SafeSysLogHandler instead of SysLogHandler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+safe_syslog_handler==0.2.0


### PR DESCRIPTION
## Premise
As I see, this python script hasn't updated for 6 years, and maybe I can improvise this script from some modules these days. I had an Error like this `[Errno 32] Broken pipe`:

> [Macro: int EPIPE](https://linuxpip.org/broken-pipe-python-error/)

> “Broken pipe.” There is no process reading from the other end of a pipe. Every library function that returns this error code also generates a SIGPIPE signal; this signal terminates the program if not handled or blocked. Thus, your program will never actually see EPIPE unless it has handled or blocked SIGPIPE.

So, after a few days of searching for the root cause of this error, yesterday I found a python module that can solve this problem. Yes! As you can see on this Pull Request Title, [safe_syslog_handler](https://github.com/intelie/safe_syslog_handler).

## Changes
- Add dependency: [safe_syslog_handler](https://pypi.org/project/safe_syslog_handler/)
- Use `socket.hostname()` instead of regex
- Simplify `socktype`

> Hopefully it can be useful and thank you :).